### PR TITLE
Fix missing _customizePartialRefreshExports() on TwentyTwenty

### DIFF
--- a/includes/class-login-designer-customizer-scripts.php
+++ b/includes/class-login-designer-customizer-scripts.php
@@ -30,6 +30,7 @@ if ( ! class_exists( 'Login_Designer_Customizer_Scripts' ) ) :
 			add_action( 'customize_controls_enqueue_scripts', array( $this, 'customize_controls' ) );
 			add_action( 'customize_controls_enqueue_scripts', array( $this, 'custom_controls' ) );
 			add_action( 'customize_controls_enqueue_scripts', array( $this, 'localization' ), 99 );
+			add_action( 'wp_footer', array( $this, 'export_preview_data' ), 1000 );
 		}
 
 		/**
@@ -94,6 +95,18 @@ if ( ! class_exists( 'Login_Designer_Customizer_Scripts' ) ) :
 			$localize = apply_filters( 'login_designer_customize_preview_localization', $localize );
 
 			wp_localize_script( 'login-designer-customize-preview', 'login_designer_script', $localize );
+		}
+
+		/**
+		 * Add export_preview_data() core function, as its missing on the login page within the Customizer.
+		 */
+		public function export_preview_data() {
+
+			if ( ! is_customize_preview() ) {
+				return;
+			}
+
+			echo '<script>var _customizePartialRefreshExports = ""</script>';
 		}
 
 		/**

--- a/includes/class-login-designer-customizer.php
+++ b/includes/class-login-designer-customizer.php
@@ -52,6 +52,11 @@ if ( ! class_exists( 'Login_Designer_Customizer' ) ) :
 		 */
 		public function customize_register( $wp_customize ) {
 
+			// Return early if the class is missing.
+			if ( ! class_exists( 'Login_Designer_Customizer_Output' ) ) {
+				return;
+			}
+
 			// Add custom controls.
 			require_once LOGIN_DESIGNER_CUSTOMIZE_CONTROLS_DIR . 'class-login-designer-range-control.php';
 			require_once LOGIN_DESIGNER_CUSTOMIZE_CONTROLS_DIR . 'class-login-designer-toggle-control.php';

--- a/includes/settings/templates.php
+++ b/includes/settings/templates.php
@@ -5,6 +5,11 @@
  * @package Login Designer
  */
 
+// Return early if the class is missing.
+if ( ! class_exists( 'Login_Designer_Templates' ) ) {
+	return;
+}
+
 // Set template choices.
 $template_class = new Login_Designer_Templates();
 


### PR DESCRIPTION
Occurs when  `customize-selective-refresh` is enqueued.